### PR TITLE
Provide default for baseDescription

### DIFF
--- a/repository/Metacello-GitBasedRepository.package/MCGitBasedNetworkRepository.class/class/basicDescription.st
+++ b/repository/Metacello-GitBasedRepository.package/MCGitBasedNetworkRepository.class/class/basicDescription.st
@@ -1,3 +1,3 @@
 accessing
 basicDescription
-  ^ self subclassResponsibility
+  ^ 'git'


### PR DESCRIPTION
In Squeak, the pragma pref

```
cacheDirectoryPath
  <preference: 'GitHub Cache' category: 'Metacello' description: '' type:
    #'String'>
  ^ MCFileTreeFileUtils current directoryPathString: self cacheDirectory
```

leads to `cacheDirectory` being sent to `MCGitBasedNetworkRepository`, leading to this stack trace:

```
MCGitBasedNetworkRepository class(Object)>>subclassResponsibility
	Receiver: MCGitBasedNetworkRepository
	Arguments and temporary variables: 

	Receiver's instance variables: 
		superclass: 	MCFileTreeRepository
		methodDict: 	a MethodDictionary(#asRepositorySpecFor:->(MCGitBasedNetworkReposit...etc...
		format: 	156
		instanceVariables: 	#('projectPath' 'projectVersion' 'repoPath' 'projectVersionP...etc...
		organization: 	('accessing' asRepositorySpecFor: directory metacelloProjectClass...etc...
		subclasses: 	{MCBitbucketRepository . MCGitHubRepository}
		name: 	#MCGitBasedNetworkRepository
		classPool: 	nil
		sharedPools: 	nil
		environment: 	Smalltalk
		category: 	#'Metacello-GitBasedRepository'
		defaultPackageExtension: 	nil
		defaultPropertyFileExtension: 	nil
		repoCacheDirectory: 	nil
		repoDownloadCache: 	nil
		siteUsername: 	nil
		sitePassword: 	nil

MCGitBasedNetworkRepository class>>basicDescription
	Receiver: MCGitBasedNetworkRepository
	Arguments and temporary variables: 

	Receiver's instance variables: 
		superclass: 	MCFileTreeRepository
		methodDict: 	a MethodDictionary(#asRepositorySpecFor:->(MCGitBasedNetworkReposit...etc...
		format: 	156
		instanceVariables: 	#('projectPath' 'projectVersion' 'repoPath' 'projectVersionP...etc...
		organization: 	('accessing' asRepositorySpecFor: directory metacelloProjectClass...etc...
		subclasses: 	{MCBitbucketRepository . MCGitHubRepository}
		name: 	#MCGitBasedNetworkRepository
		classPool: 	nil
		sharedPools: 	nil
		environment: 	Smalltalk
		category: 	#'Metacello-GitBasedRepository'
		defaultPackageExtension: 	nil
		defaultPropertyFileExtension: 	nil
		repoCacheDirectory: 	nil
		repoDownloadCache: 	nil
		siteUsername: 	nil
		sitePassword: 	nil

MCGitBasedNetworkRepository class>>defaultCacheDirectory
	Receiver: MCGitBasedNetworkRepository
	Arguments and temporary variables: 
		defaultDirectory: 	UnixFileDirectory on '/Users/tobias/dev/Squeak-Seaside'
		cacheDirectory: 	nil
	Receiver's instance variables: 
		superclass: 	MCFileTreeRepository
		methodDict: 	a MethodDictionary(#asRepositorySpecFor:->(MCGitBasedNetworkReposit...etc...
		format: 	156
		instanceVariables: 	#('projectPath' 'projectVersion' 'repoPath' 'projectVersionP...etc...
		organization: 	('accessing' asRepositorySpecFor: directory metacelloProjectClass...etc...
		subclasses: 	{MCBitbucketRepository . MCGitHubRepository}
		name: 	#MCGitBasedNetworkRepository
		classPool: 	nil
		sharedPools: 	nil
		environment: 	Smalltalk
		category: 	#'Metacello-GitBasedRepository'
		defaultPackageExtension: 	nil
		defaultPropertyFileExtension: 	nil
		repoCacheDirectory: 	nil
		repoDownloadCache: 	nil
		siteUsername: 	nil
		sitePassword: 	nil

MCGitBasedNetworkRepository class>>cacheDirectory
	Receiver: MCGitBasedNetworkRepository
	Arguments and temporary variables: 

	Receiver's instance variables: 
		superclass: 	MCFileTreeRepository
		methodDict: 	a MethodDictionary(#asRepositorySpecFor:->(MCGitBasedNetworkReposit...etc...
		format: 	156
		instanceVariables: 	#('projectPath' 'projectVersion' 'repoPath' 'projectVersionP...etc...
		organization: 	('accessing' asRepositorySpecFor: directory metacelloProjectClass...etc...
		subclasses: 	{MCBitbucketRepository . MCGitHubRepository}
		name: 	#MCGitBasedNetworkRepository
		classPool: 	nil
		sharedPools: 	nil
		environment: 	Smalltalk
		category: 	#'Metacello-GitBasedRepository'
		defaultPackageExtension: 	nil
		defaultPropertyFileExtension: 	nil
		repoCacheDirectory: 	nil
		repoDownloadCache: 	nil
		siteUsername: 	nil
		sitePassword: 	nil

MCGitBasedNetworkRepository class>>cacheDirectoryPath
	Receiver: MCGitBasedNetworkRepository
	Arguments and temporary variables: 

	Receiver's instance variables: 
		superclass: 	MCFileTreeRepository
		methodDict: 	a MethodDictionary(#asRepositorySpecFor:->(MCGitBasedNetworkReposit...etc...
		format: 	156
		instanceVariables: 	#('projectPath' 'projectVersion' 'repoPath' 'projectVersionP...etc...
		organization: 	('accessing' asRepositorySpecFor: directory metacelloProjectClass...etc...
		subclasses: 	{MCBitbucketRepository . MCGitHubRepository}
		name: 	#MCGitBasedNetworkRepository
		classPool: 	nil
		sharedPools: 	nil
		environment: 	Smalltalk
		category: 	#'Metacello-GitBasedRepository'
		defaultPackageExtension: 	nil
		defaultPropertyFileExtension: 	nil
		repoCacheDirectory: 	nil
		repoDownloadCache: 	nil
		siteUsername: 	nil
		sitePassword: 	nil

PragmaPreference>>preferenceValue
	Receiver: a PragmaPreference#'GitHub Cache' nil#'GitHub Cache' (PragmaPreference basicNew instVarAt:...etc...
	Arguments and temporary variables: 

	Receiver's instance variables: 
		name: 	#'GitHub Cache'
		value: 	nil
		defaultValue: 	nil
		helpString: 	''
		localToProject: 	false
		categoryList: 	#(#Metacello)
		changeInformee: 	nil
		changeSelector: 	nil
		type: 	#String
		provider: 	MCGitBasedNetworkRepository
		getter: 	#cacheDirectoryPath
		setter: 	#cacheDirectoryPath:

PBTextPreferenceView>>preferenceValue
	Receiver: a PBTextPreferenceView
	Arguments and temporary variables: 

	Receiver's instance variables: 
		preference: 	a PragmaPreference#'GitHub Cache' nil#'GitHub Cache' (PragmaPrefere...etc...
		actions: 	nil

…
```

Just providing the default fixes this.