### PR TITLE
fix testGithubRepositoryPatternMatchingA

### DIFF
--- a/repository/Metacello-TestsMCA.package/MetacelloGithubIssue277TestCase.class/instance/testGithubRepositoryPatternMatchingA.st
+++ b/repository/Metacello-TestsMCA.package/MetacelloGithubIssue277TestCase.class/instance/testGithubRepositoryPatternMatchingA.st
@@ -5,7 +5,7 @@ testGithubRepositoryPatternMatchingA
   | repo |
   [ 
   repo := MCGitHubRepository
-    parseLocation: 'github://GsDevKit/Seaside31:v3.?/repository'
+    parseLocation: 'github://GsDevKit/Seaside31:v3.1.3.?/repository'
     version: nil.
   self assert: repo projectVersion = 'v3.1.3.1-gs' ]
     on: Error


### PR DESCRIPTION
The tag 3.1.3.1-gs is no longer the latest for 3.?, fix accordingly.