### PR TITLE
Add Pharo5 platform attributes

### DIFF
--- a/repository/BaselineOfMetacello.package/BaselineOfMetacello.class/instance/baseline..st
+++ b/repository/BaselineOfMetacello.package/BaselineOfMetacello.class/instance/baseline..st
@@ -205,7 +205,7 @@ baseline: spec
         baseline: 'FileTree'
         with: [ spec repository: 'github://dalehenrich/filetree:pharo2.0/repository' ] ].
   spec
-    for: #(#'pharo3.x' #'pharo4.x')
+    for: #(#'pharo3.x' #'pharo4.x' #'pharo5.x')
     do: [ 
       spec
         package: 'Metacello-PharoCommonPlatform'
@@ -225,7 +225,7 @@ baseline: spec
         baseline: 'FileTree'
         with: [ spec repository: 'github://dalehenrich/filetree:pharo3.0/repository' ] ].
   spec
-    for: #(#'pharo4.x')
+    for: #(#'pharo4.x' #'pharo5.x')
     do: [ 
       spec
         baseline: 'FileTree'


### PR DESCRIPTION
As Pharo5 now removed the Pharo4.x platform attributes, these are needed to make the packages load in Pharo 5.