### PR TITLE
Try to correct issue 413 + ignore mac annoying files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 Session.vim
 .netrwhist
 *~
+**/.DS_Store

--- a/repository/BaselineOfMetacello.package/BaselineOfMetacello.class/instance/baseline..st
+++ b/repository/BaselineOfMetacello.package/BaselineOfMetacello.class/instance/baseline..st
@@ -209,7 +209,7 @@ baseline: spec
         baseline: 'FileTree'
         with: [ spec repository: 'github://dalehenrich/filetree:pharo2.0/repository' ] ].
   spec
-    for: #(#'pharo3.x' #'pharo4.x' #'pharo5.x')
+    for: #(#'pharo3.x' #'pharo4.x' #'pharo5.x' #'pharo6.x')
     do: [ 
       spec
         package: 'Metacello-PharoCommonPlatform'


### PR DESCRIPTION
@dalehenrich I think that Metacello cannot load into Pharo 6 because 'pharo5.x' was removed from metacello attributes. So I think this commit should correct the problem but I did not dug a lot so I let you validate the correction :)
As bonus I added .DS_Store in the gitignore because those files are annoying when you work on mac.

Related issues: https://github.com/dalehenrich/metacello-work/issues/413